### PR TITLE
libperm can be built `SHARED`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
 endif()
 
-add_library(libperm STATIC)
+add_library(libperm)
 set_target_properties(libperm PROPERTIES PREFIX "")
 set_internal_build_flags(libperm)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,14 @@ if (NOT DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
 endif()
 
-add_library(libperm)
+option(LIBPERM_SHARED "Whether to build libPerm as a shared (instead of a static) library" ${BUILD_SHARED_LIBS})
+if (LIBPERM_SHARED)
+	set(LIB_TYPE "SHARED")
+else()
+	set(LIB_TYPE "STATIC")
+endif()
+
+add_library(libperm ${LIB_TYPE})
 set_target_properties(libperm PROPERTIES PREFIX "")
 set_internal_build_flags(libperm)
 


### PR DESCRIPTION
hardwiring to `STATIC` makes it impossible to consume in `SHARED` libs ...